### PR TITLE
add optional air particulate density characteristic before using it

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,6 +97,7 @@ module.exports = function(homebridge){
         .on('get', this.getLightLevel.bind(this));
 
       var airQualityService = new Service.AirQualitySensor(this.name);
+      airQualityService.addOptionalCharacteristic(Characteristic.AirParticulateDensity);
       airQualityService
         .getCharacteristic(Characteristic.AirParticulateDensity)
         .on('get', this.getParticulateDensity.bind(this));


### PR DESCRIPTION
This fixes #5 (characteristic was removed in KhaosT/HAP-NodeJS@d4e45aa9453b943a40da1ab7cac5ca7a4ecf277e)