### PR TITLE
Refactored to poll values

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = function(homebridge){
   	getSensorData: function() {
   	var that = this
   	  sense.sensor_data(this.username, this.password, permanent_token, function(temperature, humidity, sound, light, air_quality){
-  		  	that.log("Current Sense Conditions: Temperature: " + temperature + "C, Humidity: " + humidity + ", Light Level: " + light);
+  		  	// that.log("Current Sense Conditions: Temperature: " + temperature + "C, Humidity: " + humidity + ", Light Level: " + light);
   			that.temperatureService.setCharacteristic(Characteristic.CurrentTemperature, temperature);
   			that.humidityService.setCharacteristic(Characteristic.CurrentRelativeHumidity, humidity);
   			that.ambientLightService.setCharacteristic(Characteristic.CurrentAmbientLightLevel, light);

--- a/index.js
+++ b/index.js
@@ -15,11 +15,9 @@ module.exports = function(homebridge){
     this.name = config['name'];
     this.username = config['username'];
     this.password = config['password'];
+	this.interval = config['interval'] || 30
     this.client_id = config['client_id'] || "8d3c1664-05ae-47e4-bcdb-477489590aa4";
     this.client_secret = config['client_secret'] || "4f771f6f-5c10-4104-bbc6-3333f5b11bf9";
-
-    this.token_url = "https://api.sense.is/v1/oauth2/token";
-    this.conditions_url = "https://api.sense.is/v1/room/current?temp_unit=c";
 
     // request token on initialization for later requests.
     // token lives for about a year
@@ -27,50 +25,24 @@ module.exports = function(homebridge){
     sense.login(this.username, this.password, this.log, function(token){
       permanent_token = token;
     });
+	
+	this.getSensorData()
   }
 
   SenseAccessory.prototype = {
 
-    getTemperature: function(callback) {
-      this.log("Requesting temperature!");
-      sense.temperature(this.username, this.password, permanent_token, function(temperature){
-        callback(null, temperature);
-      });
-    },
-
-    getHumidity: function(callback) {
-      this.log("Requesting humidity!");
-      sense.humidity(this.username, this.password, permanent_token, function(humidity){
-        callback(null, humidity);
-      });
-    },
-
-    getLightLevel: function(callback) {
-      this.log("Requesting ambient light level!");
-      sense.light(this.username, this.password, permanent_token, function(light){
-        callback(null, light);
-      });
-    },
-
-    getParticulateDensity: function(callback) {
-      this.log("Requesting ambient light level!");
-      sense.particulates(this.username, this.password, permanent_token, function(light){
-        callback(null, light);
-      });
-    },
-
-    getParticulateSize: function(callback) {
-      // Return 0 for particulate size 2.5 microns
-      this.log("Requesting particulate size");
-      callback(null, 0);
-    },
-
-    getAirQuality: function(callback) {
-      this.log("Requesting Air Quality!");
-      sense.airQuality(this.username, this.password, permanent_token, function(airQuality){
-        callback(null, airQuality);
-      });
-    },
+  	getSensorData: function() {
+  	var that = this
+  	  sense.sensor_data(this.username, this.password, permanent_token, function(temperature, humidity, sound, light, air_quality){
+  		  	that.log("Current Sense Conditions: Temperature: " + temperature + "C, Humidity: " + humidity + ", Light Level: " + light);
+  			that.temperatureService.setCharacteristic(Characteristic.CurrentTemperature, temperature);
+  			that.humidityService.setCharacteristic(Characteristic.CurrentRelativeHumidity, humidity);
+  			that.ambientLightService.setCharacteristic(Characteristic.CurrentAmbientLightLevel, light);
+  			that.airQualityService.setCharacteristic(Characteristic.AirQuality, air_quality);
+  	  });
+  	 // Updates once every 30
+  	setTimeout(this.getSensorData.bind(this), this.interval * 1000);
+  	},
 
     getServices: function() {
 
@@ -81,35 +53,15 @@ module.exports = function(homebridge){
         .setCharacteristic(Characteristic.Model, "Sense")
         .setCharacteristic(Characteristic.SerialNumber, "ABC1234");
 
-      var temperatureService = new Service.TemperatureSensor(this.name);
-      temperatureService
-        .getCharacteristic(Characteristic.CurrentTemperature)
-        .on('get', this.getTemperature.bind(this));
+      this.temperatureService = new Service.TemperatureSensor("Current Temperature");
 
-      var humidityService = new Service.HumiditySensor(this.name);
-      humidityService
-        .getCharacteristic(Characteristic.CurrentRelativeHumidity)
-        .on('get', this.getHumidity.bind(this));
+      this.humidityService = new Service.HumiditySensor("Current Humidity");
 
-      var ambientLightSerivce = new Service.LightSensor(this.name);
-      ambientLightSerivce
-        .getCharacteristic(Characteristic.CurrentAmbientLightLevel)
-        .on('get', this.getLightLevel.bind(this));
+      this.ambientLightService = new Service.LightSensor("Current Light Level");
 
-      var airQualityService = new Service.AirQualitySensor(this.name);
-      airQualityService.addOptionalCharacteristic(Characteristic.AirParticulateDensity);
-      airQualityService
-        .getCharacteristic(Characteristic.AirParticulateDensity)
-        .on('get', this.getParticulateDensity.bind(this));
-      // Is not known yet. Not very good documented by Hello Inc.
-      // airQualityService
-      //  .getCharacteristic(Characteristic.AirParticulateSize)
-      //  .on('get', this.getParticulateSize.bind(this));
-      airQualityService
-        .getCharacteristic(Characteristic.AirQuality)
-        .on('get', this.getAirQuality.bind(this));
+      this.airQualityService = new Service.AirQualitySensor("Current Air Quality");
 
-      return [temperatureService, humidityService, ambientLightSerivce, airQualityService];
+      return [this.temperatureService, this.humidityService, this.ambientLightService, this.airQualityService];
     }
   }
 }

--- a/lib/sense.js
+++ b/lib/sense.js
@@ -4,81 +4,44 @@ var token_url = 'https://api.hello.is/v1/oauth2/token';
 var current_url = 'https://api.hello.is/v1/room/current?temp_unit=c'
 var log = undefined;
 
-
-// request temperature
-exports.temperature = function(username, password, token, callback) {
+exports.sensor_data = function(username, password, token, callback) {
 	getData(username, password, token, function(json) {
-		return (json ? callback(json.temperature.value) : callback(-1));
-	});
-}
+		if (json) {
+			temperature_value = json.temperature.value;
+			humidity_value = json.humidity.value;
+			sound_value = json.sound.value;
+			light_value = json.light.value;
 
-// request humidity
-exports.humidity = function(username, password, token, callback) {
-	getData(username, password, token, function(json) {
-		return (json ?  callback(json.humidity.value) : callback(-1));
-	});
-}
+			// HMCharacteristicValueAirQuality
+			//
+			// Homekit       |Sense      |Elgato Eve
+			// --------------+-----------+------------
+			// unknown (0)   | ---       | ---
+			// excellent (1) | 0 - 50    | 0 -700
+			// good (2)      | 50 - 100  | 700 - 1100
+			// fair (3)      | 100 - 150 | 1100 - 1600
+			// inferior (4)  | 150 - 200 | 1600 - 2000
+			// poor (5)      | 200 - 300 | 2000 -
+			//               | 300 - 400 |
+			particules_value = json.particulates.value;
 
-// request particulates
-exports.particulates = function(username, password, token, callback) {
-	getData(username, password, token, function(json) {
-		return (json ? callback(json.particulates.value) : callback(-1));
-	});
-}
-
-// HMCharacteristicValueAirQuality
-//
-// Homekit       |Sense      |Elgato Eve
-// --------------+-----------+------------
-// unknown (0)   | ---       | ---
-// excellent (1) | 0 - 50    | 0 -700
-// good (2)      | 50 - 100  | 700 - 1100
-// fair (3)      | 100 - 150 | 1100 - 1600
-// inferior (4)  | 150 - 200 | 1600 - 2000
-// poor (5)      | 200 - 300 | 2000 -
-//               | 300 - 400 |
-
-// request Air Quality
-exports.airQuality = function(username, password, token, callback) {
-	getData(username, password, token, function(json) {
-		particulates = (json ? json.particulates.value :  -1);
-
-		if (particulates < 50) {
-			airQualityReturnValue = 1;
-		} else if (particulates < 100) {
-			airQualityReturnValue = 2;
-		} else if (particulates < 150) {
-			airQualityReturnValue = 3;
-		} else if (particulates < 200) {
-			airQualityReturnValue = 4;
-		} else if (particulates < 300) {
-			airQualityReturnValue = 5;
+			if (particules_value < 50) {
+				air_quality_value = 1;
+			} else if (particules_value < 100) {
+				air_quality_value = 2;
+			} else if (particules_value < 150) {
+				air_quality_value = 3;
+			} else if (particules_value < 200) {
+				air_quality_value = 4;
+			} else if (particules_value < 300) {
+				air_quality_value = 5;
+			} else {
+				air_quality_value = 0;
+			}
+			return callback(temperature_value, humidity_value, sound_value, light_value, air_quality_value)
 		} else {
-			airQualityReturnValue = 0;
+			return callback(-1, -1, -1, -1, -1)
 		}
-
-		return callback(airQualityReturnValue);
-	});
-}
-
-// HMCharacteristicAirParticulateSize
-//
-// Homekit      |Sense       |Elgato Eve
-// -------------+------------+----------–-
-// size2_5 (0)
-// size10_0 (1)
-
-// request sound
-exports.sound = function(username, password, token, callback) {
-	getData(username, password, token, function(json) {
-		return (json ? callback(json.sound.value) : callback(-1));
-	});
-}
-
-// request light
-exports.light = function(username, password, token, callback) {
-	getData(username, password, token, function(json) {
-		return (json ? callback(json.light.value) : callback(-1));
 	});
 }
 


### PR DESCRIPTION
Thanks for the great plugin!

I saw some requests to convert this plugin to poll the Sense API, rather than wait on it to be called. This has the advantage of being able to setup rules based on the current conditions.

I've refactored this plugin to poll that data by default every 30 seconds. You can customize the interval by passing in a new config value `interval`.

**UPDATE**
Originally I rolled the characteristics into a single service, but I've since reverted that change. Instead, I'm naming the service's something more intuitive, and that causes them to show up better in the UI!

Let me know if there is anything else I can do here!